### PR TITLE
Add flexbox layout

### DIFF
--- a/src/doit-ui/InlineList.jsx
+++ b/src/doit-ui/InlineList.jsx
@@ -1,0 +1,60 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { withStyles, css, withStylesPropTypes } from './withStyles';
+import { unit } from './Theme';
+
+class InlineList extends PureComponent {
+  render() {
+    const { align, children, styles, spacingBetween, verticalAlign } = this.props;
+    return (
+      <div
+        {...css(
+          styles.wrapper,
+          align === 'center' && styles.alignCenter,
+          align === 'right' && styles.alignRight,
+          verticalAlign === 'top' && styles.verticalAlignTop,
+          verticalAlign === 'bottom' && styles.verticalAlignBottom,
+        )}
+      >
+        {React.children.map(children, child => (
+          <div {...css({ marginRight: spacingBetween * unit })}>{child}</div>
+        ))}
+      </div>
+    );
+  }
+}
+
+InlineList.propTypes = {
+  ...spacingPropTypes,
+  ...withStylesPropTypes,
+  align: PropTypes.oneOf(['left', 'center', 'right']),
+  verticalAlign: PropTypes.oneOf(['top', 'middle', 'bottom']),
+  spacingBetween: PropTypes.number,
+  children: PropTypes.node,
+};
+
+InlineList.defaultProps = {
+  spacingBetween: 1,
+};
+
+export default withStyles(() => ({
+  wrapper: {
+    display: 'flex',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+  },
+  alignCenter: {
+    justifyContent: 'center',
+  },
+  alignRight: {
+    justifyContent: 'flex-end',
+  },
+  verticalAlignTop: {
+    alignItems: 'flex-start',
+  },
+  verticalAlignBottom: {
+    alignItems: 'flex-end',
+  },
+}))(InlineList);


### PR DESCRIPTION
## 작업
- flexbox 추가

## 설명
- flexbox layout으로 가로 배치를 위한 layout component를 만든다.
- flexbox layout은 flexbox layout을 적용하려는 부모 엘리먼트의 display 속성을 flex로. flexDirection 속성을 row 또는 column으로 지정하면 된다.
- flexDirection에 따라 정렬 방향을 정할 수 있다.